### PR TITLE
Add Money.from_fractional(integer, currency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### New methods
+
+- `Money.from_fractional(integer, currency)` — inverse of `#fractional`.
+  Builds a `Money` from an exact Integer count of the currency's
+  smallest unit (cents for USD, yen for JPY, fils for IQD, etc.).
+  Accepts String, Symbol, or Currency as the currency argument.
+  Raises `ArgumentError` for non-Integer input or unregistered currency.
+
 ### Documentation
 
 - `test_readme_usage` now actually asserts the README's formatting, JSON,

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ price.to_json # => "{\"currency\": \"USD\", \"amount\": \"9.99\"}"
 price.to_hash #=> {currency: "USD", amount: "9.99"}
 
 
+# Fractional units (inverse of #fractional) - exact integer arithmetic
+
+price.fractional                        #=> 999
+Mint::Money.from_fractional(999, 'USD') #=> [USD 9.99]
+Mint::Money.from_fractional(1234, 'JPY') #=> [JPY 1234]  # subunit 0 -> no scaling
+
+
 # Proportional allocation and split
 
 ten.split(3)                           #=> [[USD 3.34], [USD 3.33], [USD 3.33]]

--- a/lib/minting/money/money.rb
+++ b/lib/minting/money/money.rb
@@ -22,6 +22,37 @@ module Mint
       new(checked_currency.normalize_amount(amount), checked_currency)
     end
 
+    # Builds a Money from a fractional (smallest-unit) Integer amount.
+    # This is the inverse of {#fractional}: for USD, the fractional unit is
+    # 1 cent; for JPY it is 1 yen; for IQD it is 1 dinar (subunit 3).
+    #
+    # @param fractional [Integer] the amount expressed in the currency's
+    #   smallest unit (e.g. cents). Must be an Integer to preserve exactness.
+    # @param currency [String, Symbol, Currency] the currency identifier
+    # @return [Money] the resulting Money instance
+    # @raise [ArgumentError] if +fractional+ is not an Integer or +currency+
+    #   is not registered
+    #
+    # @example USD cents
+    #   Money.from_fractional(123_456, 'USD') #=> [USD 1234.56]
+    # @example JPY (subunit 0)
+    #   Money.from_fractional(1234, 'JPY')    #=> [JPY 1234]
+    # @example Round trip
+    #   m = Mint.money(9.99, 'USD')
+    #   Money.from_fractional(m.fractional, 'USD') == m #=> true
+    def self.from_fractional(fractional, currency)
+      raise ArgumentError, 'fractional must be an Integer' unless fractional.is_a?(Integer)
+
+      checked_currency = Mint.currency(currency)
+      unless checked_currency
+        raise ArgumentError,
+              "Currency not found (#{currency}). Check Mint.currencies"
+      end
+
+      amount = Rational(fractional, checked_currency.fractional_multiplier)
+      new(checked_currency.normalize_amount(amount), checked_currency)
+    end
+
     # Returns the ISO 3-letter currency code string.
     #
     # @return [String] the ISO currency code

--- a/test/minting_test.rb
+++ b/test/minting_test.rb
@@ -44,6 +44,13 @@ class MintingTest < Minitest::Test
     # Hash conversion
     assert_equal({ currency: 'USD', amount: '9.99' }, price.to_hash)
 
+    # Fractional units (inverse of #fractional)
+    assert_equal 999, price.fractional
+    assert_equal Mint.money(9.99, 'USD'),
+                 Mint::Money.from_fractional(999, 'USD')
+    assert_equal Mint.money(1234, 'JPY'),
+                 Mint::Money.from_fractional(1234, 'JPY')
+
     # Allocation and split
 
     assert_equal(

--- a/test/money/money_test.rb
+++ b/test/money/money_test.rb
@@ -64,4 +64,50 @@ class MoneyTest < Minitest::Test
     assert_equal 123_00, Mint.money(123, 'USD').fractional
     assert_equal 123_99, Mint.money(123.9912, 'USD').fractional
   end
+
+  def test_from_fractional
+    # Subunit 2: USD cents
+    assert_equal Mint.money(1234.56, 'USD'),
+                 Mint::Money.from_fractional(123_456, 'USD')
+    assert_equal Mint.money(0, 'USD'),
+                 Mint::Money.from_fractional(0, 'USD')
+    assert_equal Mint.money(0.01, 'USD'),
+                 Mint::Money.from_fractional(1, 'USD')
+
+    # Subunit 0: JPY yen (multiplier == 1)
+    assert_equal Mint.money(1234, 'JPY'),
+                 Mint::Money.from_fractional(1234, 'JPY')
+    assert_equal Mint.money(0, 'JPY'),
+                 Mint::Money.from_fractional(0, 'JPY')
+
+    # Subunit 3: IQD fils (multiplier == 1000)
+    assert_equal Mint.money(123.456, 'IQD'),
+                 Mint::Money.from_fractional(123_456, 'IQD')
+
+    # Accepts Symbol and Currency
+    assert_equal Mint.money(1, 'USD'),
+                 Mint::Money.from_fractional(100, :USD)
+    assert_equal Mint.money(1, 'USD'),
+                 Mint::Money.from_fractional(100, Mint.currency('USD'))
+  end
+
+  def test_from_fractional_round_trip
+    [9.99, 100, 0, 0.01, 1_234_567.89].each do |amount|
+      m = Mint.money(amount, 'USD')
+
+      assert_equal m, Mint::Money.from_fractional(m.fractional, 'USD'),
+                   "round trip failed for #{amount}"
+    end
+  end
+
+  def test_from_fractional_rejects_non_integer
+    assert_raises(ArgumentError) { Mint::Money.from_fractional(1.5, 'USD') }
+    assert_raises(ArgumentError) { Mint::Money.from_fractional('100', 'USD') }
+    assert_raises(ArgumentError) { Mint::Money.from_fractional(100r, 'USD') }
+  end
+
+  def test_from_fractional_rejects_unknown_currency
+    assert_raises(ArgumentError) { Mint::Money.from_fractional(100, 'ZZZ') }
+    assert_raises(ArgumentError) { Mint::Money.from_fractional(100, Object.new) }
+  end
 end


### PR DESCRIPTION
Mirror of #fractional: build a Money from Integer count of the currency's smallest unit (cents for USD, yen for JPY, fils for IQD, etc)

Example:  Mint::Money.from_fractional(1234_56, 'USD') #=> [USD 1234.56]